### PR TITLE
CHANGE(alertmanager): Use package for CentOS 7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ openio_alertmanager_bind_address: "{{ openio_bind_mgmt_address \
   | default(hostvars[inventory_hostname]['ansible_' + openio_alertmanager_bind_interface]['ipv4']['address']) }}"
 openio_alertmanager_bind_port: 9093
 
-openio_alertmanager_config_dir: /etc/alertmanager
+openio_alertmanager_config_dir: /etc/prometheus/
 openio_alertmanager_storage_path: /var/lib/alertmanager
 
 openio_alertmanager_service_enabled: true

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -6,6 +6,9 @@
     namespace: TRAVIS
   roles:
     - role: users
+    - role: repo
+      openio_repository_no_log: false
+      openio_repository_mirror_host: mirror2.openio.io
     - role: role_under_test
       openio_alertmanager_simple_email_enabled: true
       openio_alertmanager_simple_email_from: "test@example.com"

--- a/docker-tests/tests.bats
+++ b/docker-tests/tests.bats
@@ -21,7 +21,7 @@
 }
 
 @test 'Alertmanager config file exists' {
-  run bash -c "docker exec -ti ${SUT_ID} cat /etc/alertmanager/alertmanager.yml"
+  run bash -c "docker exec -ti ${SUT_ID} cat /etc/prometheus/alertmanager.yml"
   echo "output: "$output
   [[ "${status}" -eq "0" ]]
 }

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,0 +1,71 @@
+---
+- name: Download alertmanager binary to local folder
+  become: false
+  unarchive:
+    src: "https://github.com/prometheus/alertmanager/releases/download/v{{ openio_alertmanager_version }}/\
+    alertmanager-{{ openio_alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture]
+    | default(ansible_architecture) }}.tar.gz"
+    dest: "/tmp"
+    remote_src: true
+    creates: "/tmp/alertmanager-{{ openio_alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture]
+      | default(ansible_architecture) }}/alertmanager"
+  register: _download_binary
+  until: _download_binary is success
+  retries: 5
+  delay: 2
+  # run_once: true
+  delegate_to: localhost
+  check_mode: false
+
+- name: Propagate alertmanager and amtool binaries
+  copy:
+    src: "/tmp/alertmanager-{{ openio_alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture]
+      | default(ansible_architecture) }}/{{ item }}"
+    dest: "/usr/local/bin/{{ item }}"
+    mode: 0755
+    owner: openio
+    group: openio
+  with_items:
+    - alertmanager
+    - amtool
+
+- name: Install SELinux dependencies on RedHat OS family
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - libselinux-python
+    - policycoreutils-python
+  register: _download_packages
+  until: _download_packages is success
+  retries: 5
+  delay: 2
+  when:
+    - ansible_os_family == "RedHat"
+
+- name: Allow alertmanager to bind to port in SELinux on RedHat OS family
+  seport:
+    ports: "{{ openio_alertmanager_bind_port }}"
+    proto: tcp
+    setype: http_port_t
+    state: present
+  when:
+    - ansible_version.full is version_compare('2.4', '>=')
+    - ansible_selinux.status == "enabled"
+
+- name: Ensure systemd directory exists
+  file:
+    path: "/usr/lib/systemd/system"
+    state: directory
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Copy systemd unit
+  copy:
+    src: "alertmanager.service"
+    dest: "/usr/lib/systemd/system/alertmanager.service"
+    owner: root
+    group: root
+    mode: 0644
+...

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,11 @@
+---
+- name: Install alertmanager
+  package:
+    name: "alertmanager"
+    state: present
+  ignore_errors: "{{ ansible_check_mode }}"
+  register: install_packages
+  until: install_packages is success
+  retries: 5
+  delay: 2
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,85 +1,10 @@
 ---
-- name: Download alertmanager binary to local folder
-  become: false
-  unarchive:
-    src: "https://github.com/prometheus/alertmanager/releases/download/v{{ openio_alertmanager_version }}/\
-    alertmanager-{{ openio_alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture]
-    | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp"
-    remote_src: true
-    creates: "/tmp/alertmanager-{{ openio_alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture]
-      | default(ansible_architecture) }}/alertmanager"
-  register: _download_binary
-  until: _download_binary is success
-  retries: 5
-  delay: 2
-  # run_once: true
-  delegate_to: localhost
-  check_mode: false
-
-- name: Propagate alertmanager and amtool binaries
-  copy:
-    src: "/tmp/alertmanager-{{ openio_alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture]
-      | default(ansible_architecture) }}/{{ item }}"
-    dest: "/usr/local/bin/{{ item }}"
-    mode: 0755
-    owner: openio
-    group: openio
-  with_items:
-    - alertmanager
-    - amtool
-
-- name: Install SELinux dependencies on RedHat OS family
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - libselinux-python
-    - policycoreutils-python
-  register: _download_packages
-  until: _download_packages is success
-  retries: 5
-  delay: 2
-  when:
-    - ansible_os_family == "RedHat"
-
-- name: Allow alertmanager to bind to port in SELinux on RedHat OS family
-  seport:
-    ports: "{{ openio_alertmanager_bind_port }}"
-    proto: tcp
-    setype: http_port_t
-    state: present
-  when:
-    - ansible_version.full is version_compare('2.4', '>=')
-    - ansible_selinux.status == "enabled"
-
-- name: Create required directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: openio
-    group: openio
-    mode: 0755
-  with_items:
-    - "{{ openio_alertmanager_config_dir }}"
-    - "{{ openio_alertmanager_config_dir }}/templates"
-    - "{{ openio_alertmanager_storage_path }}"
-
-- name: Ensure systemd directory exists
-  file:
-    path: "/usr/lib/systemd/system"
-    state: directory
-    owner: root
-    group: root
-    mode: 0644
-
-- name: Copy systemd unit
-  copy:
-    src: "alertmanager.service"
-    dest: "/usr/lib/systemd/system/alertmanager.service"
-    owner: root
-    group: root
-    mode: 0644
+- name: "Include {{ ansible_distribution }} tasks"
+  include_tasks: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_os_family }}.yml"
+  tags: install
 
 - name: Create defaults file
   template:
@@ -90,12 +15,24 @@
     mode: 0644
   register: _am_defaults
 
+- name: Create required directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  with_items:
+    - "{{ openio_alertmanager_config_dir }}"
+    - "{{ openio_alertmanager_config_dir }}/templates"
+    - "{{ openio_alertmanager_storage_path }}"
+
 - name: Set alertmanager configuration
   template:
     src: "alertmanager.yml.j2"
     dest: "{{ openio_alertmanager_config_dir }}/alertmanager.yml"
-    owner: "root"
-    group: "root"
+    owner: root
+    group: root
     # validate: "amtool check-config %s"
   tags: configure
   register: _am_conf
@@ -106,5 +43,19 @@
     name: alertmanager
     state: "{{ 'started' if openio_alertmanager_provision_only else 'restarted' }}"
     enabled: "{{ openio_alertmanager_service_enabled }}"
-  when: _am_defaults is changed or _am_conf is changed
+  when:
+    - _am_defaults is changed or _am_conf is changed
+
+- name: Check that service is up
+  uri:
+    url: "http://{{ openio_alertmanager_bind_address }}:{{ openio_alertmanager_bind_port }}"
+    return_content: true
+    status_code: 200
+    register: _am_check
+    retries: 3
+    delay: 5
+    until: _am_check is success
+    changed_when: false
+  when:
+    - not openio_alertmanager_provision_only
 ...


### PR DESCRIPTION
 ##### SUMMARY

Alertmanager package is available in openio repos, we use it for CentOS.
Debian/Ubuntu has no package yet, so we use the old method. Defaults
have been adapted to match package requirements

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION