### PR TITLE
BUGFIX/MINOR(alertmanager): Fix the use of install/configure tags

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -16,6 +16,7 @@
   # run_once: true
   delegate_to: localhost
   check_mode: false
+  tags: install
 
 - name: Propagate alertmanager and amtool binaries
   copy:
@@ -28,6 +29,7 @@
   with_items:
     - alertmanager
     - amtool
+  tags: install
 
 - name: Install SELinux dependencies on RedHat OS family
   package:
@@ -42,6 +44,7 @@
   delay: 2
   when:
     - ansible_os_family == "RedHat"
+  tags: install
 
 - name: Allow alertmanager to bind to port in SELinux on RedHat OS family
   seport:
@@ -52,6 +55,7 @@
   when:
     - ansible_version.full is version_compare('2.4', '>=')
     - ansible_selinux.status == "enabled"
+  tags: install
 
 - name: Ensure systemd directory exists
   file:
@@ -60,6 +64,7 @@
     owner: root
     group: root
     mode: 0644
+  tags: install
 
 - name: Copy systemd unit
   copy:
@@ -68,4 +73,5 @@
     owner: root
     group: root
     mode: 0644
+  tags: install
 ...

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -8,4 +8,5 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,9 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
-  tags: install
+  tags:
+    - install
+    - configure
 
 - name: Create defaults file
   template:
@@ -14,6 +16,7 @@
     group: root
     mode: 0644
   register: _am_defaults
+  tags: configure
 
 - name: Create required directories
   file:
@@ -26,6 +29,7 @@
     - "{{ openio_alertmanager_config_dir }}"
     - "{{ openio_alertmanager_config_dir }}/templates"
     - "{{ openio_alertmanager_storage_path }}"
+  tags: configure
 
 - name: Set alertmanager configuration
   template:
@@ -33,9 +37,9 @@
     dest: "{{ openio_alertmanager_config_dir }}/alertmanager.yml"
     owner: root
     group: root
-    # validate: "amtool check-config %s"
-  tags: configure
+    validate: "amtool check-config %s"
   register: _am_conf
+  tags: configure
 
 - name: Ensure alertmanager service is started and enabled
   systemd:
@@ -45,6 +49,7 @@
     enabled: "{{ openio_alertmanager_service_enabled }}"
   when:
     - _am_defaults is changed or _am_conf is changed
+  tags: configure
 
 - name: Check that service is up
   uri:
@@ -58,4 +63,5 @@
     changed_when: false
   when:
     - not openio_alertmanager_provision_only
+  tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the install tag and then only the configure tag

Supersedes: https://github.com/open-io/ansible-role-openio-alertmanager/pull/2

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION