### PR TITLE
BUGFIX/MINOR(alertmanager): Fix indent filter for older jinja2 versions

### DIFF
--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -21,5 +21,5 @@ route:
   {{ openio_alertmanager_route | to_nice_yaml() | indent(2) }}
   routes:
   {{ (openio_alertmanager_default_routes + openio_alertmanager_custom_routes + (openio_alertmanager_simple_email_route
-    if openio_alertmanager_simple_email_enabled else [])) | to_nice_yaml(indent=2) | indent(2, first=False) }}
+    if openio_alertmanager_simple_email_enabled else [])) | to_nice_yaml(indent=2) | indent(2, indentfirst=false) }}
 ...


### PR DESCRIPTION
 ##### SUMMARY
Templating was using indent(first=False) which is only available since
jinja 2.10. This makes use of the older argument indentfirst which is
available in older versions.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION