### PR TITLE
BUGFIX/MINOR(alert_manager): Fix warning on loop item

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
       VERSION: 7
 #    - DISTRIBUTION: centos
 #      VERSION: 8
-    - DISTRIBUTION: ubuntu
-      VERSION: 16.04
+#    - DISTRIBUTION: ubuntu
+#      VERSION: 16.04
     - DISTRIBUTION: ubuntu
       VERSION: 18.04
 #    - DISTRIBUTION: debian

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -21,40 +21,16 @@
 - name: Propagate alertmanager and amtool binaries
   copy:
     src: "/tmp/alertmanager-{{ openio_alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture]
-      | default(ansible_architecture) }}/{{ item }}"
-    dest: "/usr/local/bin/{{ item }}"
+      | default(ansible_architecture) }}/{{ file }}"
+    dest: "/usr/local/bin/{{ file }}"
     mode: 0755
     owner: openio
     group: openio
   with_items:
     - alertmanager
     - amtool
-  tags: install
-
-- name: Install SELinux dependencies on RedHat OS family
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - libselinux-python
-    - policycoreutils-python
-  register: _download_packages
-  until: _download_packages is success
-  retries: 5
-  delay: 2
-  when:
-    - ansible_os_family == "RedHat"
-  tags: install
-
-- name: Allow alertmanager to bind to port in SELinux on RedHat OS family
-  seport:
-    ports: "{{ openio_alertmanager_bind_port }}"
-    proto: tcp
-    setype: http_port_t
-    state: present
-  when:
-    - ansible_version.full is version_compare('2.4', '>=')
-    - ansible_selinux.status == "enabled"
+  loop_control:
+    loop_var: file
   tags: install
 
 - name: Ensure systemd directory exists


### PR DESCRIPTION
 ##### SUMMARY

* Define a loop variable
* Remove tasks Red Hat in file `tasks/Debian.yml`

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
TASK [alertmanager : Propagate alertmanager and amtool binaries] *******************************************************************************************************************************************
Thursday 12 December 2019  13:51:27 +0000 (0:00:00.078)       0:12:36.692 *****
[WARNING]: The loop variable 'item' is already in use. You should set the `loop_var` value in the `loop_control` option for the task to something else to avoid variable collisions and unexpected
behavior.
```