### PR TITLE
CHANGE(alertmanager): remove `oio-` prefix to service_type

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - include_role:
     name: openio-service
   vars:
-    openio_service_type: "oio-alertmanager"
+    openio_service_type: "alertmanager"
     openio_service_namespace: "{{ openio_alertmanager_namespace }}"
     openio_service_maintenance_mode: "{{ openio_alertmanager_maintenance_mode }}"
     openio_service_directories:


### PR DESCRIPTION
 ##### SUMMARY
no need to have `oio-` in front of service name for monitoring

 ##### IMPACT
service name and path changes

 ##### ADDITIONAL INFORMATION